### PR TITLE
Fixes for successful synthesis in ISE 14.7

### DIFF
--- a/minerva/reg.py
+++ b/minerva/reg.py
@@ -22,7 +22,7 @@ class RegisterFileBase:
         self._write_ports = []
 
     def scan(self, method):
-        for submodule, name in self.source._submodules:
+        for submodule in self.source._anon_submodules:
             if hasattr(submodule, method):
                 for reg in getattr(submodule, method)():
                     if reg.addr in self._register_map:

--- a/minerva/units/exception.py
+++ b/minerva/units/exception.py
@@ -49,6 +49,7 @@ class ExceptionUnit(Elaboratable, AutoCSR):
 
         trap_pe = m.submodules.trap_pe = PriorityEncoder(16)
         m.d.comb += [
+            trap_pe.i.eq(0),
             trap_pe.i[Cause.FETCH_MISALIGNED   ].eq(self.x_misaligned_fetch),
             trap_pe.i[Cause.FETCH_ACCESS_FAULT ].eq(self.x_ibus_error),
             trap_pe.i[Cause.ILLEGAL_INSTRUCTION].eq(self.x_illegal),
@@ -66,6 +67,7 @@ class ExceptionUnit(Elaboratable, AutoCSR):
 
         interrupt_pe = m.submodules.interrupt_pe = PriorityEncoder(16)
         m.d.comb += [
+            interrupt_pe.i.eq(0),
             interrupt_pe.i[Cause.M_SOFTWARE_INTERRUPT].eq(self.mip.r.msip & self.mie.r.msie),
             interrupt_pe.i[Cause.M_TIMER_INTERRUPT   ].eq(self.mip.r.mtip & self.mie.r.mtie),
             interrupt_pe.i[Cause.M_EXTERNAL_INTERRUPT].eq(self.mip.r.meip & self.mie.r.meie)


### PR DESCRIPTION
I was trying to generate Verilog code for the Minerva core and synthesize it using Xilinx ISE 14.7.

Setup:
python 3.6.5
m-labs/nmigen@698b005
YosysHQ/yosys@9cb0456b
ISE 14.7

The first patch is necessary due to a recent change in nmigen: m-labs/nmigen@698b005.

I'm not sure about the second patch. There are the two priority encoders in the exception unit where not all of the inputs are used, and only the used ones are assigned in `m.d.comb`. Without the patch, nmigen/yosys would generate `always @*` statements to assign all-zeros to the PE inputs in addition to the usual assignments:

```
always @* begin
 trap_pe_i = 16'h0000;
end
always @* begin
 interrupt_pe_i = 16'h0000;
end
```

Synthesis fails with 
> No signals referenced in statement with implicit sensitivity list

The code seems wrong to me, and the synthesis failure not a Xilinx ISE quirk. I never did Verilog though. With the patch the `always` blocks are gone; `interrupt_pe_i` and `trap_pe_i` become `wire` instead of `reg`.

Now in VHDL I would probably create a `process`, declare a `variable` for the input vector, assign all-zeros and then assign the bits I'm actually using. Finally the `variable` is assigned to a `signal`. Only the final result is used for the signal assignment. Is this similar when assigning within `m.d.comb`?

So my question and why I'm even elaborating this issue: should the default assignment (as in my patch) be the right way to do it, or is either nMigen or yosys responsible for handling unassigned bits correctly?