### PR TITLE
Request for using nmigen v0.1rc1

### DIFF
--- a/minerva/cache.py
+++ b/minerva/cache.py
@@ -1,7 +1,7 @@
 from nmigen import *
 from nmigen.asserts import *
 from nmigen.lib.coding import Encoder
-from nmigen.tools import log2_int
+from nmigen.utils import log2_int
 
 
 __all__ = ["L1Cache"]

--- a/minerva/csr.py
+++ b/minerva/csr.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 from nmigen import *
 from nmigen.hdl.rec import *
-from nmigen.tools import bits_for
+from nmigen.utils import bits_for
 
 
 __all__ = ["CSRAccess", "CSR", "AutoCSR", "CSRFile"]

--- a/minerva/test/test_cache.py
+++ b/minerva/test/test_cache.py
@@ -1,5 +1,5 @@
 from nmigen import *
-from nmigen.tools import log2_int
+from nmigen.utils import log2_int
 from nmigen.test.tools import *
 from nmigen.asserts import *
 

--- a/minerva/test/test_cache.py
+++ b/minerva/test/test_cache.py
@@ -1,6 +1,6 @@
 from nmigen import *
 from nmigen.utils import log2_int
-from nmigen.test.tools import *
+from nmigen.test.utils import *
 from nmigen.asserts import *
 
 from ..cache import L1Cache

--- a/minerva/test/test_units_divider.py
+++ b/minerva/test/test_units_divider.py
@@ -1,6 +1,6 @@
 from nmigen import *
 from nmigen.back.pysim import *
-from nmigen.test.tools import *
+from nmigen.test.utils import *
 
 from ..units.divider import *
 from ..isa import Funct3

--- a/minerva/test/test_units_multiplier.py
+++ b/minerva/test/test_units_multiplier.py
@@ -1,6 +1,6 @@
 from nmigen import *
 from nmigen.back.pysim import *
-from nmigen.test.tools import *
+from nmigen.test.utils import *
 
 from ..units.multiplier import *
 from ..isa import Funct3

--- a/minerva/units/fetch.py
+++ b/minerva/units/fetch.py
@@ -1,5 +1,5 @@
 from nmigen import *
-from nmigen.tools import log2_int
+from nmigen.utils import log2_int
 
 from ..cache import *
 from ..wishbone import *

--- a/minerva/units/loadstore.py
+++ b/minerva/units/loadstore.py
@@ -1,5 +1,5 @@
 from nmigen import *
-from nmigen.tools import log2_int
+from nmigen.utils import log2_int
 from nmigen.lib.fifo import SyncFIFO
 
 from ..cache import *


### PR DESCRIPTION
Hello, I am working on a [project](https://git.m-labs.hk/M-Labs/HeavyX) that is going to use both the Minerva soft-core and [nmigen v0.1rc1](https://github.com/m-labs/nmigen/tree/v0.1rc1). By observation, the following changes to Minerva might be needed due to syntactical changes in nmigen: 

* `nmigen.tools`→ 'nmigen.utils'
* `nmigen.test.tools`→ 'nmigen.test.utils'

I believe these changes only affect the code for the testing procedure, but my solution will not provide backward-compatibility (for testing purposes). I look forward to seeing your review. Thank you.