### PR TITLE
Some structural changes:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 /.eggs
 
 # tests
-**/test/spec_*/
+test/spec_*/
 *.vcd
 *.gtkw
 
@@ -12,3 +12,6 @@ __pycache__/
 *.il
 *.v
 /build
+
+# macOS
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Minerva currently requires Python 3.6+ and [nMigen][2] on its `master` branch.
     python setup.py develop
     python cli.py generate -t v > minerva.v
 
+    # generate verilog with cache
+    python cli.py --with-icache generate -t v > minerva.v
+
     # run some tests
     python setup.py test
     python -m unittest test/test_cache.py
@@ -25,6 +28,9 @@ To use Minerva in its minimal configuration, you need to wire the following port
 * `external_interrupt`
 * `timer_interrupt`
 * `software_interrupt`
+
+For an example of Minerva running some code, see 
+[here](https://github.com/jfng/minerva-examples).
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minerva currently requires Python 3.6+ and [nMigen][2] on its `master` branch.
 
     # generate verilog
     python setup.py develop
-    python cli.py generate > minerva.v
+    python cli.py generate -t v > minerva.v
 
     # run some tests
     python setup.py test

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ Minerva is a CPU core that currently implements the [RISC-V][1] RV32IM instructi
 
 Minerva currently requires Python 3.6+ and [nMigen][2] on its `master` branch.
 
-    python setup.py install
+    # generate verilog
+    python setup.py develop
     python cli.py generate > minerva.v
+
+    # run some tests
+    python setup.py test
+    python -m unittest test/test_cache.py
 
 To use Minerva in its minimal configuration, you need to wire the following ports to `minerva_cpu`:
 

--- a/minerva/fhdltestcase.py
+++ b/minerva/fhdltestcase.py
@@ -1,0 +1,128 @@
+import os
+import re
+import shutil
+import subprocess
+import textwrap
+import traceback
+import unittest
+import warnings
+from contextlib import contextmanager
+
+from nmigen.hdl.ast import *
+from nmigen.hdl.ir import *
+from nmigen.back import rtlil
+
+
+__all__ = ["FHDLTestCase"]
+
+
+def tool_env_var(name):
+    return name.upper().replace("-", "_")
+
+def _get_tool(name):
+    return os.environ.get(tool_env_var(name), name)
+
+class ToolNotFound(Exception):
+    pass
+
+def require_tool(name):
+    env_var = tool_env_var(name)
+    path = _get_tool(name)
+    if shutil.which(path) is None:
+        if env_var in os.environ:
+            raise ToolNotFound("Could not find required tool {} in {} as "
+                               "specified via the {} environment variable".
+                               format(name, path, env_var))
+        else:
+            raise ToolNotFound("Could not find required tool {} in PATH. Place "
+                               "it directly in PATH or specify path explicitly "
+                               "via the {} environment variable".
+                               format(name, env_var))
+    return path
+
+
+class FHDLTestCase(unittest.TestCase):
+    def assertRepr(self, obj, repr_str):
+        if isinstance(obj, list):
+            obj = Statement.cast(obj)
+        def prepare_repr(repr_str):
+            repr_str = re.sub(r"\s+",   " ",  repr_str)
+            repr_str = re.sub(r"\( (?=\()", "(", repr_str)
+            repr_str = re.sub(r"\) (?=\))", ")", repr_str)
+            return repr_str.strip()
+        self.assertEqual(prepare_repr(repr(obj)), prepare_repr(repr_str))
+
+    @contextmanager
+    def assertRaises(self, exception, msg=None):
+        with super().assertRaises(exception) as cm:
+            yield
+        if msg is not None:
+            # WTF? unittest.assertRaises is completely broken.
+            self.assertEqual(str(cm.exception), msg)
+
+    @contextmanager
+    def assertRaisesRegex(self, exception, regex=None):
+        with super().assertRaises(exception) as cm:
+            yield
+        if regex is not None:
+            # unittest.assertRaisesRegex also seems broken...
+            self.assertRegex(str(cm.exception), regex)
+
+    @contextmanager
+    def assertWarns(self, category, msg=None):
+        with warnings.catch_warnings(record=True) as warns:
+            yield
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(warns[0].category, category)
+        if msg is not None:
+            self.assertEqual(str(warns[0].message), msg)
+
+    def assertFormal(self, spec, mode="bmc", depth=1):
+        caller, *_ = traceback.extract_stack(limit=2)
+        spec_root, _ = os.path.splitext(caller.filename)
+        spec_root = os.path.abspath(spec_root)
+        spec_dir = os.path.dirname(spec_root)
+        spec_name = "{}_{}".format(
+            os.path.basename(spec_root).replace("test_", "spec_"),
+            caller.name.replace("test_", "")
+        )
+
+        # The sby -f switch seems not fully functional when sby is reading from stdin.
+        if os.path.exists(os.path.join(spec_dir, spec_name)):
+            shutil.rmtree(os.path.join(spec_dir, spec_name))
+
+        if mode == "hybrid":
+            # A mix of BMC and k-induction, as per personal communication with Clifford Wolf.
+            script = "setattr -unset init w:* a:nmigen.sample_reg %d"
+            mode   = "bmc"
+        else:
+            script = ""
+
+        config = textwrap.dedent("""\
+        [options]
+        mode {mode}
+        depth {depth}
+        wait on
+
+        [engines]
+        smtbmc
+
+        [script]
+        read_ilang top.il
+        prep
+        {script}
+
+        [file top.il]
+        {rtlil}
+        """).format(
+            mode=mode,
+            depth=depth,
+            script=script,
+            rtlil=rtlil.convert(Fragment.get(spec, platform="formal"))
+        )
+        with subprocess.Popen([require_tool("sby"), "-f", "-d", spec_name], cwd=spec_dir,
+                              universal_newlines=True,
+                              stdin=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+            stdout, stderr = proc.communicate(config)
+            if proc.returncode != 0:
+                self.fail("Formal verification failed:\n" + stdout)

--- a/news.md
+++ b/news.md
@@ -1,0 +1,10 @@
+ - update install requires - don't think whitequark is still pushing to pypi
+
+ - follow pep setup.py suggestions allowing for easy testing and 
+sane imports
+   - remove relative imports
+   - ```python3 setup.py test``` now works
+ - replace dependency of internal nmigen FHDLTestCase using ```nmigen.test.utils``` (which whitequark has already deprecated) - formal tests still passing
+ - remove unused signals from L1Cache - formal tests still passing
+ - add README link to Minerva "hello world"
+ - add "hello world" as test case

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,12 @@ setup(
     author_email="jf@lambdaconcept.com",
     license="BSD",
     python_requires="~=3.6",
-    install_requires=["nmigen>=0.1rc1"],
+    install_requires=['nmigen @ git+https://github.com/nmigen/nmigen.git'],
     extras_require={ "debug": ["jtagtap"] },
     packages=find_packages(),
     project_urls={
         "Source Code": "https://github.com/lambdaconcept/minerva",
         "Bug Tracker": "https://github.com/lambdaconcept/minerva/issues"
-    }
+    },
+    test_suite='test',
 )

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,9 +1,8 @@
 from nmigen import *
-from nmigen.test.utils import *
 from nmigen.asserts import *
 
-from ..cache import L1Cache
-
+from minerva.cache import L1Cache
+from minerva.fhdltestcase import FHDLTestCase
 
 class L1CacheSpec(Elaboratable):
     def __init__(self, cache):
@@ -84,8 +83,6 @@ class L1CacheSpec(Elaboratable):
 
         return m
 
-
-# FIXME: FHDLTestCase is internal to nMigen, we shouldn't use it.
 class L1CacheTestCase(FHDLTestCase):
     def check(self, cache):
         self.assertFormal(L1CacheSpec(cache), mode="bmc", depth=12)

--- a/test/test_units_divider.py
+++ b/test/test_units_divider.py
@@ -3,9 +3,8 @@ import unittest
 from nmigen import *
 from nmigen.back.pysim import *
 
-from ..units.divider import *
-from ..isa import Funct3
-
+from minerva.units.divider import *
+from minerva.isa import Funct3
 
 def test_op(funct3, src1, src2, result):
     def test(self):

--- a/test/test_units_multiplier.py
+++ b/test/test_units_multiplier.py
@@ -3,8 +3,8 @@ import unittest
 from nmigen import *
 from nmigen.back.pysim import *
 
-from ..units.multiplier import *
-from ..isa import Funct3
+from minerva.units.multiplier import *
+from minerva.isa import Funct3
 
 
 def test_op(funct3, src1, src2, result):


### PR DESCRIPTION
 - update install requires - ~don't think whitequark is still pushing to pypi anymore and~ nMigen/nMigen master has a number of changes such as removal of support for FHDLTestCase and improving support for YosysCXX
 - follow pep setup.py suggestions allowing for easy testing and 
sane imports
   - remove relative imports in the ```test``` folder
   - ```python3 setup.py test``` now works
 - replace dependency of internal nmigen FHDLTestCase using ```nmigen.test.utils``` (which whitequark has already deprecated) - formal tests still passing